### PR TITLE
adds LM Studio as LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,13 +29,21 @@ OLLAMA_HOST=http://localhost:11434
 # Legacy single-model knob (used as fallback if the two below are empty)
 OLLAMA_MODEL=llama3.2-vision
 # Per-task model selection — vision = screen-aware, text = Code Mode / journal Q&A.
-# Pick any model you've `ollama pull`'d. Tray → Ollama → "Pull recommended"
-# downloads curated picks (qwen2-vl, llama3.2-vision, qwen2.5-coder, etc.)
-OLLAMA_VISION_MODEL=
-OLLAMA_TEXT_MODEL=
+OLLAMA_VISION_MODEL=qwen2.5vl:7b
+OLLAMA_TEXT_MODEL=qwen2.5vl:7b
+
+# ── LM Studio Settings ───────────────────────────────────────
+# Alternative to Ollama. Start LM Studio → Developer tab → Start Server,
+# load a model, then select "lmstudio" from Tray → Model. No key needed.
+LMSTUDIO_HOST=http://localhost:1234/v1
+# Leave empty to use whatever model is currently loaded in LM Studio.
+LMSTUDIO_MODEL=
 
 # ── App Settings ─────────────────────────────────────────────
 # Hotkey to activate push-to-talk (default: ctrl+alt+space)
 CLICKY_HOTKEY=ctrl+alt+space
 # Whisper model size: tiny, base, small, medium (larger = slower but more accurate)
 WHISPER_MODEL=base
+
+# Which LLM to use on startup: claude, openai, gemini, ollama, lmstudio
+CLICKY_ACTIVE_LLM=lmstudio

--- a/ai/lmstudio_provider.py
+++ b/ai/lmstudio_provider.py
@@ -1,0 +1,119 @@
+"""
+LM Studio provider.
+
+LM Studio exposes an OpenAI-compatible REST server (default:
+http://localhost:1234/v1) once you press "Start Server" in its Developer
+tab. This provider talks to that endpoint directly over HTTP so we don't
+need the `openai` SDK's base_url plumbing — same approach as
+ollama_provider.py, kept dependency-free and consistent with the rest of
+this file's style.
+
+No API key is required for local use; LM Studio ignores the field.
+"""
+
+import json
+from typing import AsyncIterator, List
+
+import httpx
+
+from ai.base_provider import BaseLLMProvider, Message
+from config import cfg
+
+
+class LMStudioProvider(BaseLLMProvider):
+    """
+    Streams responses from a local LM Studio server (OpenAI-compatible
+    /v1/chat/completions endpoint).
+
+    Model selection: LM Studio serves whichever model is currently loaded
+    in the app. cfg.lmstudio_model, if set, is sent explicitly (useful if
+    you keep several models loaded); otherwise we ask LM Studio to use
+    whatever's active via a placeholder id, which it accepts.
+    """
+
+    def __init__(self):
+        self._base = cfg.lmstudio_host.rstrip("/")
+        self._model = cfg.lmstudio_model
+
+    async def stream_response(
+        self,
+        user_text: str,
+        screenshots_b64: List[str],
+        history: List[Message],
+        system_prompt: str,
+        model: str | None = None,
+    ) -> AsyncIterator[str]:
+        chosen = model or self._model or "local-model"
+
+        messages = [{"role": "system", "content": system_prompt}]
+        for msg in history:
+            messages.append({"role": msg.role, "content": msg.content})
+
+        # OpenAI-style multimodal content blocks (LM Studio's vision models
+        # accept the same image_url/base64 shape as OpenAI's API).
+        content: list = []
+        for img_b64 in screenshots_b64:
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"},
+            })
+        content.append({"type": "text", "text": user_text})
+        messages.append({"role": "user", "content": content if screenshots_b64 else user_text})
+
+        payload = {
+            "model": chosen,
+            "messages": messages,
+            "max_tokens": 1024,
+            "stream": True,
+        }
+
+        async with httpx.AsyncClient(timeout=120) as client:
+            try:
+                async with client.stream(
+                    "POST",
+                    f"{self._base}/chat/completions",
+                    json=payload,
+                ) as response:
+                    if response.status_code == 404:
+                        raise RuntimeError(
+                            "LM Studio server not reachable at "
+                            f"{self._base}. Open LM Studio → Developer tab → "
+                            "Start Server, and make sure a model is loaded."
+                        )
+                    response.raise_for_status()
+                    async for line in response.aiter_lines():
+                        if not line.strip() or not line.startswith("data:"):
+                            continue
+                        data_str = line[len("data:"):].strip()
+                        if data_str == "[DONE]":
+                            break
+                        try:
+                            data = json.loads(data_str)
+                            delta = data["choices"][0]["delta"].get("content")
+                            if delta:
+                                yield delta
+                        except (json.JSONDecodeError, KeyError, IndexError):
+                            continue
+            except httpx.ConnectError as e:
+                raise RuntimeError(
+                    "Can't reach LM Studio. Is the local server running? "
+                    "(LM Studio → Developer tab → Start Server)"
+                ) from e
+
+    async def health_check(self) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                r = await client.get(f"{self._base}/models")
+                return r.status_code == 200
+        except Exception:
+            return False
+
+    async def list_models(self) -> List[str]:
+        """Return model ids LM Studio currently reports via /v1/models."""
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                r = await client.get(f"{self._base}/models")
+                data = r.json()
+                return [m["id"] for m in data.get("data", [])]
+        except Exception:
+            return []

--- a/companion_manager.py
+++ b/companion_manager.py
@@ -495,6 +495,9 @@ class CompanionManager(QObject):
             elif provider == "copilot":
                 from ai.github_copilot_provider import GitHubCopilotProvider
                 self._llm = GitHubCopilotProvider()
+            elif provider == "lmstudio":
+                from ai.lmstudio_provider import LMStudioProvider
+                self._llm = LMStudioProvider()
             else:
                 _ensure_ollama_running()
                 from ai.ollama_provider import OllamaProvider

--- a/config.py
+++ b/config.py
@@ -29,6 +29,11 @@ class Config:
     ollama_vision_model: str = field(default_factory=lambda: os.getenv("OLLAMA_VISION_MODEL", "") or os.getenv("OLLAMA_MODEL", "llama3.2-vision"))
     ollama_text_model:   str = field(default_factory=lambda: os.getenv("OLLAMA_TEXT_MODEL", "") or "llama3.2:3b")
 
+    # LM Studio — local OpenAI-compatible server (Developer tab → Start Server).
+    # No key needed. Leave LMSTUDIO_MODEL empty to use whatever's loaded.
+    lmstudio_host: str = field(default_factory=lambda: os.getenv("LMSTUDIO_HOST", "http://localhost:1234/v1"))
+    lmstudio_model: str = field(default_factory=lambda: os.getenv("LMSTUDIO_MODEL", ""))
+
     # STT
     deepgram_api_key: Optional[str] = field(default_factory=lambda: os.getenv("DEEPGRAM_API_KEY") or None)
     whisper_model: str = field(default_factory=lambda: os.getenv("WHISPER_MODEL", "base"))
@@ -82,7 +87,8 @@ class Config:
             pass
         if self.google_api_key:
             out.append("gemini")
-        out.append("ollama")   # always available if the daemon is running
+        out.append("ollama")     # always available if the daemon is running
+        out.append("lmstudio")   # always available if the local server is running
         return out
 
     def set_active_llm(self, name: str) -> None:
@@ -145,6 +151,8 @@ class Config:
             "ollama_model": self.ollama_model,
             "ollama_vision_model": self.get_ollama_model("vision"),
             "ollama_text_model":   self.get_ollama_model("text"),
+            "lmstudio_host": self.lmstudio_host,
+            "lmstudio_model": self.lmstudio_model or "(auto — whatever's loaded)",
         }
 
     # ── Ollama runtime model selection ───────────────────────────────────


### PR DESCRIPTION
Adds LM Studio support as an alternative to Ollama for fully local, key-free LLM use.

- New `ai/lmstudio_provider.py`, talks to LM Studio's OpenAI-compatible server (`localhost:1234/v1`)
- Dispatch added in `companion_manager.py`
- Config options in `config.py` (`lmstudio_host`, `lmstudio_model`) and `.env.example`
- Select via Tray → Model → lmstudio

Tested locally with qwen2.5-vl-7b — vision + chat both working, streaming responses confirmed.

Note: LM Studio's default context length (2048) is too small for screenshots; users need to raise it in LM Studio when loading a model. Mentioned this isn't handled automatically — happy to add a startup check if useful.