### PR TITLE
Feature/custom instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,13 +29,21 @@ OLLAMA_HOST=http://localhost:11434
 # Legacy single-model knob (used as fallback if the two below are empty)
 OLLAMA_MODEL=llama3.2-vision
 # Per-task model selection — vision = screen-aware, text = Code Mode / journal Q&A.
-# Pick any model you've `ollama pull`'d. Tray → Ollama → "Pull recommended"
-# downloads curated picks (qwen2-vl, llama3.2-vision, qwen2.5-coder, etc.)
-OLLAMA_VISION_MODEL=
-OLLAMA_TEXT_MODEL=
+OLLAMA_VISION_MODEL=qwen2.5vl:7b
+OLLAMA_TEXT_MODEL=qwen2.5vl:7b
+
+# ── LM Studio Settings ───────────────────────────────────────
+# Alternative to Ollama. Start LM Studio → Developer tab → Start Server,
+# load a model, then select "lmstudio" from Tray → Model. No key needed.
+LMSTUDIO_HOST=http://localhost:1234/v1
+# Leave empty to use whatever model is currently loaded in LM Studio.
+LMSTUDIO_MODEL=
 
 # ── App Settings ─────────────────────────────────────────────
 # Hotkey to activate push-to-talk (default: ctrl+alt+space)
 CLICKY_HOTKEY=ctrl+alt+space
 # Whisper model size: tiny, base, small, medium (larger = slower but more accurate)
 WHISPER_MODEL=base
+
+# Which LLM to use on startup: claude, openai, gemini, ollama, lmstudio
+CLICKY_ACTIVE_LLM=lmstudio

--- a/ai/lmstudio_provider.py
+++ b/ai/lmstudio_provider.py
@@ -1,0 +1,119 @@
+"""
+LM Studio provider.
+
+LM Studio exposes an OpenAI-compatible REST server (default:
+http://localhost:1234/v1) once you press "Start Server" in its Developer
+tab. This provider talks to that endpoint directly over HTTP so we don't
+need the `openai` SDK's base_url plumbing — same approach as
+ollama_provider.py, kept dependency-free and consistent with the rest of
+this file's style.
+
+No API key is required for local use; LM Studio ignores the field.
+"""
+
+import json
+from typing import AsyncIterator, List
+
+import httpx
+
+from ai.base_provider import BaseLLMProvider, Message
+from config import cfg
+
+
+class LMStudioProvider(BaseLLMProvider):
+    """
+    Streams responses from a local LM Studio server (OpenAI-compatible
+    /v1/chat/completions endpoint).
+
+    Model selection: LM Studio serves whichever model is currently loaded
+    in the app. cfg.lmstudio_model, if set, is sent explicitly (useful if
+    you keep several models loaded); otherwise we ask LM Studio to use
+    whatever's active via a placeholder id, which it accepts.
+    """
+
+    def __init__(self):
+        self._base = cfg.lmstudio_host.rstrip("/")
+        self._model = cfg.lmstudio_model
+
+    async def stream_response(
+        self,
+        user_text: str,
+        screenshots_b64: List[str],
+        history: List[Message],
+        system_prompt: str,
+        model: str | None = None,
+    ) -> AsyncIterator[str]:
+        chosen = model or self._model or "local-model"
+
+        messages = [{"role": "system", "content": system_prompt}]
+        for msg in history:
+            messages.append({"role": msg.role, "content": msg.content})
+
+        # OpenAI-style multimodal content blocks (LM Studio's vision models
+        # accept the same image_url/base64 shape as OpenAI's API).
+        content: list = []
+        for img_b64 in screenshots_b64:
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"},
+            })
+        content.append({"type": "text", "text": user_text})
+        messages.append({"role": "user", "content": content if screenshots_b64 else user_text})
+
+        payload = {
+            "model": chosen,
+            "messages": messages,
+            "max_tokens": 1024,
+            "stream": True,
+        }
+
+        async with httpx.AsyncClient(timeout=120) as client:
+            try:
+                async with client.stream(
+                    "POST",
+                    f"{self._base}/chat/completions",
+                    json=payload,
+                ) as response:
+                    if response.status_code == 404:
+                        raise RuntimeError(
+                            "LM Studio server not reachable at "
+                            f"{self._base}. Open LM Studio → Developer tab → "
+                            "Start Server, and make sure a model is loaded."
+                        )
+                    response.raise_for_status()
+                    async for line in response.aiter_lines():
+                        if not line.strip() or not line.startswith("data:"):
+                            continue
+                        data_str = line[len("data:"):].strip()
+                        if data_str == "[DONE]":
+                            break
+                        try:
+                            data = json.loads(data_str)
+                            delta = data["choices"][0]["delta"].get("content")
+                            if delta:
+                                yield delta
+                        except (json.JSONDecodeError, KeyError, IndexError):
+                            continue
+            except httpx.ConnectError as e:
+                raise RuntimeError(
+                    "Can't reach LM Studio. Is the local server running? "
+                    "(LM Studio → Developer tab → Start Server)"
+                ) from e
+
+    async def health_check(self) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                r = await client.get(f"{self._base}/models")
+                return r.status_code == 200
+        except Exception:
+            return False
+
+    async def list_models(self) -> List[str]:
+        """Return model ids LM Studio currently reports via /v1/models."""
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                r = await client.get(f"{self._base}/models")
+                data = r.json()
+                return [m["id"] for m in data.get("data", [])]
+        except Exception:
+            return []

--- a/audio/ambient_listener.py
+++ b/audio/ambient_listener.py
@@ -16,7 +16,7 @@ from typing import Callable, Optional
 import numpy as np
 import sounddevice as sd
 
-from audio.capture import pcm16_to_wav, SAMPLE_RATE
+from audio.capture import pcm16_to_wav, resample_pcm, SAMPLE_RATE
 
 
 class Mode(Enum):
@@ -54,9 +54,12 @@ class AmbientListener:
         self,
         on_level: Callable[[float], None],
         on_wake: Callable[[], None],
+        device: Optional[int] = None,
     ):
         self._on_level = on_level
         self._on_wake = on_wake
+        self._device = device       # None = system default input device
+        self._stream_rate = SAMPLE_RATE   # actual rate the stream opens at
 
         self._mode: Mode = Mode.STANDBY
         self._stream: Optional[sd.InputStream] = None
@@ -87,13 +90,30 @@ class AmbientListener:
         if self._running:
             return
         self._running = True
-        self._stream = sd.InputStream(
-            samplerate=SAMPLE_RATE,
-            channels=1,
-            dtype="int16",
-            blocksize=FRAMES_PER_BLOCK,
-            callback=self._callback,
-        )
+        try:
+            self._stream = sd.InputStream(
+                samplerate=SAMPLE_RATE,
+                channels=1,
+                dtype="int16",
+                blocksize=FRAMES_PER_BLOCK,
+                callback=self._callback,
+                device=self._device,
+            )
+            self._stream_rate = SAMPLE_RATE
+        except Exception:
+            # Device doesn't support 16kHz directly — open at its native
+            # rate and resample every block to 16kHz for Whisper.
+            info = sd.query_devices(self._device, "input")
+            native_rate = int(info["default_samplerate"])
+            self._stream_rate = native_rate
+            self._stream = sd.InputStream(
+                samplerate=native_rate,
+                channels=1,
+                dtype="int16",
+                blocksize=int(native_rate * BLOCK_MS / 1000),
+                callback=self._callback,
+                device=self._device,
+            )
         self._stream.start()
 
     def stop(self):
@@ -133,6 +153,11 @@ class AmbientListener:
             return
 
         pcm_int16 = indata[:, 0] if indata.ndim == 2 else indata
+        if self._stream_rate != SAMPLE_RATE:
+            pcm_int16 = np.frombuffer(
+                resample_pcm(pcm_int16.tobytes(), self._stream_rate, SAMPLE_RATE),
+                dtype=np.int16,
+            )
         pcm_float = pcm_int16.astype(np.float32) / 32768.0
         rms = float(np.sqrt(np.mean(pcm_float ** 2)))
         self._on_level(rms)

--- a/audio/capture.py
+++ b/audio/capture.py
@@ -58,8 +58,97 @@ class MicCapture:
         self._on_chunk(pcm_bytes)
 
 
+def apply_noise_gate(pcm_data: bytes, threshold: float = 0.008) -> bytes:
+    """
+    Suppresses low-level background noise (fans, hum, AC) by zeroing out
+    blocks quieter than `threshold`, computed per ~30ms block so actual
+    speech isn't affected — only steady background hiss between words.
+    """
+    audio = np.frombuffer(pcm_data, dtype=np.int16).astype(np.float32) / 32768.0
+    if len(audio) == 0:
+        return pcm_data
+    block = max(1, SAMPLE_RATE * 30 // 1000)  # ~30ms
+    out = audio.copy()
+    for i in range(0, len(audio), block):
+        chunk = audio[i:i + block]
+        if len(chunk) == 0:
+            continue
+        rms = float(np.sqrt(np.mean(chunk ** 2)))
+        if rms < threshold:
+            out[i:i + block] = 0.0
+    return (out * 32767).astype(np.int16).tobytes()
+
+
+def trim_silence(pcm_data: bytes, threshold: float = 0.008, pad_ms: int = 150) -> bytes:
+    """
+    Trims leading/trailing silence from a recorded utterance before it goes
+    to Whisper — reduces hallucinated/garbled transcriptions caused by
+    long silent stretches at the start or end of a push-to-talk clip.
+    Keeps a small padding around detected speech.
+    """
+    audio = np.frombuffer(pcm_data, dtype=np.int16).astype(np.float32) / 32768.0
+    if len(audio) == 0:
+        return pcm_data
+    block = max(1, SAMPLE_RATE * 30 // 1000)
+    n_blocks = len(audio) // block
+    if n_blocks == 0:
+        return pcm_data
+    is_speech = [
+        float(np.sqrt(np.mean(audio[i * block:(i + 1) * block] ** 2))) > threshold
+        for i in range(n_blocks)
+    ]
+    if not any(is_speech):
+        return pcm_data  # all silence — let caller decide (e.g. skip/re-record)
+    first = next(i for i, s in enumerate(is_speech) if s)
+    last = len(is_speech) - 1 - next(i for i, s in enumerate(reversed(is_speech)) if s)
+    pad_blocks = max(1, pad_ms * SAMPLE_RATE // 1000 // block)
+    start = max(0, (first - pad_blocks) * block)
+    end = min(len(audio), (last + 1 + pad_blocks) * block)
+    trimmed = audio[start:end]
+    return (trimmed * 32767).astype(np.int16).tobytes()
+
+
+def resample_pcm(pcm_data: bytes, from_rate: int, to_rate: int = SAMPLE_RATE) -> bytes:
+    """
+    Linear-interpolation resample (no scipy dependency). Used when a mic's
+    native sample rate isn't 16kHz and the device can't be opened directly
+    at 16kHz — keeps Whisper input consistent regardless of mic hardware.
+    """
+    if from_rate == to_rate:
+        return pcm_data
+    audio = np.frombuffer(pcm_data, dtype=np.int16).astype(np.float32)
+    duration = len(audio) / from_rate
+    n_out = int(duration * to_rate)
+    if n_out <= 0:
+        return pcm_data
+    x_old = np.linspace(0, duration, num=len(audio), endpoint=False)
+    x_new = np.linspace(0, duration, num=n_out, endpoint=False)
+    resampled = np.interp(x_new, x_old, audio)
+    return resampled.astype(np.int16).tobytes()
+
+
+def normalize_audio(pcm_data: bytes, target_rms: float = 0.15) -> bytes:
+    """
+    Auto-gain: boosts quiet mics so Whisper gets a consistent volume level.
+    Scales int16 PCM so its RMS matches target_rms, capped to avoid clipping.
+    No-op on silence (avoids amplifying noise floor).
+    """
+    audio = np.frombuffer(pcm_data, dtype=np.int16).astype(np.float32) / 32768.0
+    rms = float(np.sqrt(np.mean(audio ** 2))) if len(audio) else 0.0
+    if rms < 1e-4:
+        return pcm_data  # silence — nothing to boost
+    gain = min(target_rms / rms, 8.0)  # cap gain to avoid amplifying noise/clipping
+    boosted = np.clip(audio * gain, -1.0, 1.0)
+    return (boosted * 32767).astype(np.int16).tobytes()
+
+
 def pcm16_to_wav(pcm_data: bytes, sample_rate: int = SAMPLE_RATE) -> bytes:
-    """Wraps raw PCM16 bytes in a WAV container."""
+    """Wraps raw PCM16 bytes in a WAV container, after noise-gate and
+    auto-gain normalization. (Silence trimming is applied separately by
+    callers that record full utterances — see trim_silence — since the
+    wake-word path intentionally pads short clips with silence.)"""
+    pcm_data = apply_noise_gate(pcm_data)
+    pcm_data = normalize_audio(pcm_data)
     import struct
     channels = 1
     bits = 16

--- a/audio/stt/faster_whisper_stt.py
+++ b/audio/stt/faster_whisper_stt.py
@@ -3,7 +3,7 @@ import asyncio
 from typing import Optional
 
 from audio.stt.base_stt import BaseSTT
-from audio.capture import pcm16_to_wav
+from audio.capture import pcm16_to_wav, trim_silence
 from config import cfg
 
 _model_cache = None
@@ -26,6 +26,7 @@ class FasterWhisperSTT(BaseSTT):
     """
 
     async def transcribe(self, pcm_bytes: bytes, sample_rate: int = 16000) -> str:
+        pcm_bytes = trim_silence(pcm_bytes)
         wav_bytes = pcm16_to_wav(pcm_bytes, sample_rate)
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(None, self._run, wav_bytes)
@@ -37,7 +38,8 @@ class FasterWhisperSTT(BaseSTT):
             f.write(wav_bytes)
             path = f.name
         try:
-            segments, _ = model.transcribe(path, beam_size=5, language="en")
+            lang = cfg.whisper_language or None  # None = auto-detect
+            segments, _ = model.transcribe(path, beam_size=5, language=lang)
             return " ".join(s.text.strip() for s in segments).strip()
         finally:
             os.unlink(path)

--- a/audio/stt/whisper_cpp_stt.py
+++ b/audio/stt/whisper_cpp_stt.py
@@ -25,12 +25,16 @@ from pathlib import Path
 from typing import Optional
 
 from audio.stt.base_stt import BaseSTT
+from audio.capture import pcm16_to_wav, trim_silence
 from config import cfg
 
 
 # Model size:  tiny / base / small / medium / large
-# Append `.en` for English-only (smaller, faster, more accurate for English).
-DEFAULT_MODEL = os.getenv("WHISPERCPP_MODEL", "base.en")
+# NOTE: do NOT default to a `.en` suffix — those are English-only and will
+# mistranscribe every other language as garbled English-sounding text.
+# WHISPERCPP_MODEL in .env lets you pick your own; WHISPER_MODEL is reused
+# as a fallback so users don't need to configure the same thing twice.
+DEFAULT_MODEL = os.getenv("WHISPERCPP_MODEL", "") or cfg.whisper_model or "base"
 
 
 class WhisperCppSTT(BaseSTT):
@@ -67,13 +71,17 @@ class WhisperCppSTT(BaseSTT):
         """Convert raw 16-bit mono PCM @ 16 kHz → text."""
         if not pcm_bytes:
             return ""
+        pcm_bytes = trim_silence(pcm_bytes)
 
-        # whisper.cpp expects a WAV file path. Stage to a temp file —
-        # cleanup is automatic.
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(None, self._sync_transcribe, pcm_bytes)
 
     def _sync_transcribe(self, pcm_bytes: bytes) -> str:
+        # pcm16_to_wav applies noise-gate + auto-gain, then wraps as WAV —
+        # we only need the processed PCM back out, so unwrap the header.
+        wav_bytes = pcm16_to_wav(pcm_bytes)
+        pcm_bytes = wav_bytes[44:]  # strip standard 44-byte WAV header
+
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
             tmp_path = tmp.name
         try:
@@ -83,7 +91,8 @@ class WhisperCppSTT(BaseSTT):
                 w.setframerate(16000)    # AmbientListener captures at 16 kHz
                 w.writeframes(pcm_bytes)
             model = self._load()
-            segments = model.transcribe(tmp_path)
+            lang = cfg.whisper_language or ""
+            segments = model.transcribe(tmp_path, language=lang)
             return " ".join(s.text.strip() for s in segments).strip()
         finally:
             try:

--- a/companion_manager.py
+++ b/companion_manager.py
@@ -386,6 +386,7 @@ class CompanionManager(QObject):
         self._listener = AmbientListener(
             on_level=self._handle_level,
             on_wake=self._handle_wake,
+            device=cfg.mic_device_index,
         )
 
         # Background asyncio loop
@@ -797,8 +798,11 @@ class CompanionManager(QObject):
 
             # ── Per-turn enrichment: code mode, language, OCR, attached docs ──
             code_active = self._code_mode_auto and code_mode.is_code_window(title)
-            lang_code = (multilang.detect_language(transcript)
-                         if self._multilang else "en")
+            if cfg.response_language:
+                lang_code = cfg.response_language   # user-forced — always wins
+            else:
+                lang_code = (multilang.detect_language(transcript)
+                             if self._multilang else "en")
 
             # OCR fallback for fine print (only if user actually asks to read)
             ocr_extra = ""
@@ -1332,6 +1336,28 @@ class CompanionManager(QObject):
         # Force the provider instance to re-read cfg on next call
         if cfg.llm_provider() == "ollama":
             self._llm = None
+
+    def set_response_language(self, code: str):
+        """Tray callback — pin Clicky's reply language ('' = auto-detect)."""
+        cfg.response_language = code
+
+    def set_mic_device(self, device_index: int):
+        """Tray callback — switch input device without restarting the app."""
+        cfg.mic_device_index = device_index if device_index >= 0 else None
+        try:
+            self._listener.stop()
+        except Exception:
+            pass
+        from audio.ambient_listener import AmbientListener
+        self._listener = AmbientListener(
+            on_level=self._handle_level,
+            on_wake=self._handle_wake,
+            device=cfg.mic_device_index,
+        )
+        try:
+            self._listener.start()
+        except Exception as e:
+            self.sig_error.emit(f"Could not start mic: {e}")
 
     def pull_ollama_model(self, name: str):
         """Trigger `ollama pull <name>` in the background. Status via sig_ollama_pull_status."""

--- a/companion_manager.py
+++ b/companion_manager.py
@@ -495,6 +495,9 @@ class CompanionManager(QObject):
             elif provider == "copilot":
                 from ai.github_copilot_provider import GitHubCopilotProvider
                 self._llm = GitHubCopilotProvider()
+            elif provider == "lmstudio":
+                from ai.lmstudio_provider import LMStudioProvider
+                self._llm = LMStudioProvider()
             else:
                 _ensure_ollama_running()
                 from ai.ollama_provider import OllamaProvider

--- a/companion_manager.py
+++ b/companion_manager.py
@@ -12,6 +12,7 @@ import re
 import threading
 import time
 from datetime import datetime
+from pathlib import Path
 from typing import List, Optional
 
 from PyQt6.QtCore import QObject, pyqtSignal
@@ -133,101 +134,11 @@ ABSOLUTE QUIZ RULES (override everything else):
 STYLE: short, friendly, never more than 2 sentences. End every turn with a
 question mark."""
 
-    return f"""You are Clicky, a VISUAL AI tutor running on Windows. You live
-next to the user's cursor. Your job is to *show*, not just tell.
-
-{chr(10).join(ctx_lines)}
-
-COORDINATE SYSTEM (applies to every tag below): coordinates are NORMALIZED
-0-1000 relative to the screenshot. x=0 is the LEFT edge, x=1000 the RIGHT
-edge; y=0 is the TOP, y=1000 the BOTTOM. The exact centre of the screen is
-500,500. Sizes/radii use the same scale (100 = 10% of screen width).
-
-HARD RULES (never break):
-  1. LOCATE QUESTIONS ("where is X", "how do I click Y", "show me X", "find X"):
-     • If a DETECTED ELEMENT coordinate is provided above, emit EXACTLY ONE tag
-       [POINT:x,y:label:screen1]  using those coordinates and a 1-3 word label.
-       Follow with ONE sentence explaining what it is. Nothing else.
-     • If no coordinate is provided AND you can see the element in the screenshot,
-       emit [POINT:x,y:label:screen1] at your best-guess normalized coordinates.
-     • If the element is NOT visible, say plainly: "I don't see X on this page —
-       you're looking at [describe actual page]. Want me to help you get there?"
-       DO NOT invent generic directions like "click the search bar at the top".
-
-  2. MULTI-STEP TASKS (export, install, configure, setup, etc.):
-     Describe ONLY the next single step. Point at it. End with "Say 'next' when
-     ready." Never dump a numbered list of 5 steps in one response.
-
-  3. VISION: describe only what is ACTUALLY in the screenshot. The user said
-     something, but trust your eyes over their words. If they say "YouTube" and
-     the screen shows Google, tell them so.
-
-  4. WEB SEARCH: when [Web Search Results] appear in the system prompt, you MUST
-     use them as your primary source. Give a DIRECT, SPECIFIC answer — never say
-     "I don't know" or list vague options if the results contain real names,
-     rankings, or facts. Commit to what the search found. Cite like [1], [2].
-     Today is {today}. Your training data is stale — always prefer search results
-     over your own memory for anything recent (news, rankings, current events,
-     "who is", "what is the best", "latest", "top", etc.).
-
-  5. PUBLIC figures, celebrities, YouTubers, athletes, politicians, companies,
-     products, brands — ANSWER FREELY using your training data + search results.
-     NEVER refuse with "I can't identify people" / "I can't help with that" /
-     "personal or sensitive". The user is asking a tutor question, not running
-     facial recognition — these are public figures with public Wikipedia pages.
-     If asked "who is MrBeast" — say "MrBeast (Jimmy Donaldson) is an American
-     YouTuber known for…". Same for any other public person.
-
-  6. DRAW ON SCREEN to teach. You can draw directly over the user's screen —
-     shapes float above their content, animate in the order you write them,
-     and stay visible until the next question. Tags (coords normalized 0-1000,
-     trailing :color always optional):
-       [LINE:x1,y1->x2,y2:color]         straight line
-       [ARROW:x1,y1->x2,y2:color]        line with arrowhead (points at x2,y2)
-       [CIRCLE:x,y,r:label:color]        ring; label optional
-       [RECT:x1,y1,x2,y2:color]          rectangle by opposite corners
-       [POLY:x1,y1 x2,y2 x3,y3:color]    closed shape, 3+ points (triangles!)
-       [TEXT:x,y:content:color:size]     text; size s|m|l (default m)
-       [ANGLE:x,y,s,rot:color]           right-angle marker at corner (x,y)
-       [CLEAR]                           wipe all drawings
-     Colors: blue red green yellow orange purple white cyan (default blue).
-     For real UI elements use anchors instead of guessing coordinates:
-       [CIRCLE:@Save button]  [UNDERLINE:@File menu]  — resolved pixel-perfectly.
-
-     TEACHING WITH DRAWINGS: when the user asks you to explain something
-     visible on screen (a figure, chart, diagram, equation, code), draw ON it
-     — trace its edges, label its parts, add helper lines — interleaving tags
-     with your spoken words in the order a teacher draws on a whiteboard.
-     Place TEXT next to what it names, never covering it. Use up to ~10 shapes
-     for a full lesson, 1-2 for a quick highlight.
-
-     ACCURACY DISCIPLINE (critical): if DETECTED FIGURES are listed in this
-     prompt, you MUST copy those vertex numbers into your tags EXACTLY — they
-     are ground truth from Clicky's local vision. Only estimate coordinates
-     for things the detector didn't list. When estimating: fix the figure's
-     bounding box first, derive every endpoint from it, and reuse IDENTICAL
-     numbers for shared vertices (a triangle's corner appears in two LINE
-     tags: same numbers both times). When unsure, err 5-10 units INSIDE the
-     figure. If there is no figure on screen, draw your own diagram in a
-     clear empty area.
-
-     NARRATION SYNC: Clicky speaks your response sentence by sentence and
-     draws each sentence's tags WHILE saying that sentence. So: put every tag
-     immediately after the words that describe it, spread tags across the
-     lesson (1-2 per sentence), and never dump all tags at the start or end.
-     Short sentence, stroke. Short sentence, stroke. That's the rhythm of a
-     teacher at a whiteboard.
-     Example — right triangle visible on screen, user asks about Pythagoras:
-       "See this corner? [ANGLE:320,620,25:yellow] That right angle is what
-        makes the theorem work. This vertical side [LINE:320,620->320,380:red]
-        is a [TEXT:290,500:a:red:l], the bottom [LINE:320,620->620,620:green]
-        is b [TEXT:470,655:b:green:l], and the long side
-        [LINE:320,380->620,620:cyan] is the hypotenuse c
-        [TEXT:490,470:c:cyan:l]. The rule: [TEXT:640,340:a² + b² = c²:white:l]"
-     (Adapt coordinates to where the figure ACTUALLY is in the screenshot.)
-
-STYLE: warm, concise, teacher-y. 1-2 sentences per step. No markdown bullets
-unless genuinely listing options.{_code_addendum(code_active)}{_lang_addendum(language_code)}{extra}"""
+    from config import _TECHNICAL_RULES
+    base = cfg.custom_instructions.strip()
+    base = base.replace("{{CONTEXT}}", chr(10).join(ctx_lines))
+    base = base.replace("{{TODAY}}", today)
+    return base + _TECHNICAL_RULES + _code_addendum(code_active) + _lang_addendum(language_code) + extra
 
 
 def _code_addendum(active: bool) -> str:
@@ -1337,9 +1248,31 @@ class CompanionManager(QObject):
         if cfg.llm_provider() == "ollama":
             self._llm = None
 
+    def set_custom_instructions(self, text: str):
+        """Tray callback — restrict/steer what Clicky helps with. Persists
+        to .env so it survives a restart, not just this session."""
+        cfg.custom_instructions = text.strip()
+        try:
+            from dotenv import set_key
+            env_path = Path(__file__).parent / ".env"
+            if not env_path.exists():
+                env_path.touch()
+            escaped = text.strip().replace("\n", "\\n")
+            set_key(str(env_path), "CUSTOM_INSTRUCTIONS", escaped)
+        except Exception as e:
+            self.sig_error.emit(f"Could not save instructions: {e}")
+
     def set_response_language(self, code: str):
         """Tray callback — pin Clicky's reply language ('' = auto-detect)."""
         cfg.response_language = code
+        try:
+            from dotenv import set_key
+            env_path = Path(__file__).parent / ".env"
+            if not env_path.exists():
+                env_path.touch()
+            set_key(str(env_path), "RESPONSE_LANGUAGE", code)
+        except Exception as e:
+            self.sig_error.emit(f"Could not save language setting: {e}")
 
     def set_mic_device(self, device_index: int):
         """Tray callback — switch input device without restarting the app."""

--- a/config.py
+++ b/config.py
@@ -13,6 +13,81 @@ for _name in (".env", ".env.local"):
         load_dotenv(_p, override=True)
 
 
+DEFAULT_SYSTEM_PROMPT = """You are Clicky, a VISUAL AI tutor running on Windows. You live
+next to the user's cursor. Your job is to *show*, not just tell.
+
+{{CONTEXT}}
+
+HARD RULES (never break):
+  1. LOCATE QUESTIONS ("where is X", "how do I click Y", "show me X", "find X"):
+     Point at it and explain in ONE sentence. If it's not visible, say so
+     plainly instead of guessing.
+
+  2. MULTI-STEP TASKS (export, install, configure, setup, etc.):
+     Describe ONLY the next single step, then end with "Say 'next' when
+     ready." Never dump a numbered list of 5 steps in one response.
+
+  3. VISION: describe only what is ACTUALLY in the screenshot. Trust your
+     eyes over the user's words.
+
+  4. WEB SEARCH: when search results appear, use them as your primary
+     source and give a direct answer — never say "I don't know" if the
+     results contain real facts. Today is {{TODAY}}.
+
+  5. PUBLIC figures, celebrities, companies, products — answer freely.
+     Never refuse with "I can't identify people" — these are public figures
+     with public information available.
+
+STYLE: warm, concise, teacher-y. 1-2 sentences per step. No markdown bullets
+unless genuinely listing options."""
+
+
+# Technical rules Clicky needs to actually draw on screen and point at
+# elements correctly. Always appended after the user-editable prompt above
+# — kept separate because breaking this syntax breaks pointing/drawing, and
+# most users have no reason to touch it.
+_TECHNICAL_RULES = """
+
+COORDINATE SYSTEM (applies to every tag below): coordinates are NORMALIZED
+0-1000 relative to the screenshot. x=0 is the LEFT edge, x=1000 the RIGHT
+edge; y=0 is the TOP, y=1000 the BOTTOM. The exact centre of the screen is
+500,500. Sizes/radii use the same scale (100 = 10% of screen width).
+
+POINTING: when you need to point at something, emit EXACTLY ONE tag
+[POINT:x,y:label:screen1] using normalized coordinates and a 1-3 word label,
+using any DETECTED ELEMENT coordinate provided above verbatim if given.
+
+DRAWING TAGS (coords normalized 0-1000, trailing :color always optional):
+  [LINE:x1,y1->x2,y2:color]         straight line
+  [ARROW:x1,y1->x2,y2:color]        line with arrowhead (points at x2,y2)
+  [CIRCLE:x,y,r:label:color]        ring; label optional
+  [RECT:x1,y1,x2,y2:color]          rectangle by opposite corners
+  [POLY:x1,y1 x2,y2 x3,y3:color]    closed shape, 3+ points (triangles!)
+  [TEXT:x,y:content:color:size]     text; size s|m|l (default m)
+  [ANGLE:x,y,s,rot:color]           right-angle marker at corner (x,y)
+  [CLEAR]                           wipe all drawings
+Colors: blue red green yellow orange purple white cyan (default blue).
+For real UI elements use anchors instead of guessing coordinates:
+  [CIRCLE:@Save button]  [UNDERLINE:@File menu]  — resolved pixel-perfectly.
+
+TEACHING WITH DRAWINGS: when explaining something visible on screen (a
+figure, chart, diagram, equation, code), draw ON it — trace edges, label
+parts, add helper lines — interleaving tags with your spoken words in the
+order a teacher draws on a whiteboard. Place TEXT next to what it names,
+never covering it. Use up to ~10 shapes for a full lesson, 1-2 for a quick
+highlight.
+
+ACCURACY DISCIPLINE: if DETECTED FIGURES are listed above, copy those
+vertex numbers into your tags EXACTLY. Only estimate coordinates for things
+not listed. When estimating: fix the figure's bounding box first, derive
+every endpoint from it, and reuse IDENTICAL numbers for shared vertices.
+
+NARRATION SYNC: Clicky speaks your response sentence by sentence and draws
+each sentence's tags WHILE saying that sentence — put every tag immediately
+after the words that describe it, spread across the lesson (1-2 tags per
+sentence), never dump all tags at the start or end."""
+
+
 @dataclass
 class Config:
     # LLM
@@ -46,6 +121,11 @@ class Config:
     # Fixed reply language (ISO 639-1, e.g. "de"). Empty = auto-detect per
     # message (can mix languages if transcription is inconsistent).
     response_language: str = field(default_factory=lambda: os.getenv("RESPONSE_LANGUAGE", ""))
+    # User-defined scope/rules appended to every system prompt (e.g. "only
+    # help with Excel, refuse anything else"). Empty = no restriction.
+    custom_instructions: str = field(default_factory=lambda: os.getenv(
+        "CUSTOM_INSTRUCTIONS", DEFAULT_SYSTEM_PROMPT
+    ).replace("\\n", "\n"))
 
     # TTS
     elevenlabs_api_key: Optional[str] = field(default_factory=lambda: os.getenv("ELEVENLABS_API_KEY") or None)

--- a/config.py
+++ b/config.py
@@ -37,6 +37,15 @@ class Config:
     # STT
     deepgram_api_key: Optional[str] = field(default_factory=lambda: os.getenv("DEEPGRAM_API_KEY") or None)
     whisper_model: str = field(default_factory=lambda: os.getenv("WHISPER_MODEL", "base"))
+    # ISO code (e.g. "de", "en"). Empty = auto-detect language per utterance.
+    whisper_language: str = field(default_factory=lambda: os.getenv("WHISPER_LANGUAGE", ""))
+    # sounddevice input device index. Empty/unset = system default mic.
+    mic_device_index: Optional[int] = field(default_factory=lambda: (
+        int(v) if (v := os.getenv("MIC_DEVICE_INDEX", "").strip()) else None
+    ))
+    # Fixed reply language (ISO 639-1, e.g. "de"). Empty = auto-detect per
+    # message (can mix languages if transcription is inconsistent).
+    response_language: str = field(default_factory=lambda: os.getenv("RESPONSE_LANGUAGE", ""))
 
     # TTS
     elevenlabs_api_key: Optional[str] = field(default_factory=lambda: os.getenv("ELEVENLABS_API_KEY") or None)

--- a/config.py
+++ b/config.py
@@ -29,6 +29,11 @@ class Config:
     ollama_vision_model: str = field(default_factory=lambda: os.getenv("OLLAMA_VISION_MODEL", "") or os.getenv("OLLAMA_MODEL", "llama3.2-vision"))
     ollama_text_model:   str = field(default_factory=lambda: os.getenv("OLLAMA_TEXT_MODEL", "") or "llama3.2:3b")
 
+    # LM Studio — local OpenAI-compatible server (Developer tab → Start Server).
+    # No key needed. Leave LMSTUDIO_MODEL empty to use whatever's loaded.
+    lmstudio_host: str = field(default_factory=lambda: os.getenv("LMSTUDIO_HOST", "http://localhost:1234/v1"))
+    lmstudio_model: str = field(default_factory=lambda: os.getenv("LMSTUDIO_MODEL", ""))
+
     # STT
     deepgram_api_key: Optional[str] = field(default_factory=lambda: os.getenv("DEEPGRAM_API_KEY") or None)
     whisper_model: str = field(default_factory=lambda: os.getenv("WHISPER_MODEL", "base"))
@@ -82,7 +87,8 @@ class Config:
             pass
         if self.google_api_key:
             out.append("gemini")
-        out.append("ollama")   # always available if the daemon is running
+        out.append("ollama")     # always available if the daemon is running
+        out.append("lmstudio")   # always available if the local server is running
         return out
 
     def set_active_llm(self, name: str) -> None:
@@ -145,6 +151,8 @@ class Config:
             "ollama_model": self.ollama_model,
             "ollama_vision_model": self.get_ollama_model("vision"),
             "ollama_text_model":   self.get_ollama_model("text"),
+            "lmstudio_host": self.lmstudio_host,
+            "lmstudio_model": self.lmstudio_model or "(auto — whatever's loaded)",
         }
 
     # ── Ollama runtime model selection ───────────────────────────────────

--- a/main.py
+++ b/main.py
@@ -245,6 +245,8 @@ def main():
     tray.on_ollama_set_model.connect(manager.set_ollama_model)
     tray.on_ollama_pull.connect(manager.pull_ollama_model)
     tray.on_ollama_refresh.connect(manager.refresh_ollama_models)
+    tray.on_set_mic_device.connect(manager.set_mic_device)
+    tray.on_set_response_language.connect(manager.set_response_language)
 
     # When the installed-model list arrives, push it into the tray submenu
     manager.sig_ollama_models.connect(tray.set_ollama_models)

--- a/main.py
+++ b/main.py
@@ -247,6 +247,7 @@ def main():
     tray.on_ollama_refresh.connect(manager.refresh_ollama_models)
     tray.on_set_mic_device.connect(manager.set_mic_device)
     tray.on_set_response_language.connect(manager.set_response_language)
+    tray.on_set_custom_instructions.connect(manager.set_custom_instructions)
 
     # When the installed-model list arrives, push it into the tray submenu
     manager.sig_ollama_models.connect(tray.set_ollama_models)

--- a/ui/tray.py
+++ b/ui/tray.py
@@ -51,6 +51,8 @@ class TrayManager(QObject):
     on_attach_doc         = pyqtSignal()
     on_run_setup          = pyqtSignal()
     on_diagnostics        = pyqtSignal()
+    on_set_mic_device     = pyqtSignal(int)     # sounddevice input device index
+    on_set_response_language = pyqtSignal(str)  # "" = auto-detect, else ISO code
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -70,6 +72,7 @@ class TrayManager(QObject):
         )
         self._search_enabled = True
         self._wake_enabled = True
+        self._response_language = ""
         self._slow_enabled = False
         self._quiz_enabled = False
         self._privacy_enabled = True
@@ -146,6 +149,8 @@ class TrayManager(QObject):
         wake_action.setChecked(self._wake_enabled)
         wake_action.triggered.connect(self._toggle_wake)
         self._wake_action = wake_action
+
+        self._build_language_submenu(menu)
 
         # ── Tutor toggles ──
         menu.addSeparator()
@@ -250,6 +255,7 @@ class TrayManager(QObject):
 
         # ── Setup / Diagnostics ──
         setup_menu = menu.addMenu("Setup && Diagnostics")
+        self._build_mic_submenu(setup_menu)
         run_setup = setup_menu.addAction("Run setup wizard again…")
         run_setup.triggered.connect(self.on_run_setup)
         diag = setup_menu.addAction("Save diagnostics report…")
@@ -263,6 +269,50 @@ class TrayManager(QObject):
         self._tray.setContextMenu(menu)
         # Keep refs to prevent GC
         self._menu = menu
+
+    def _build_language_submenu(self, parent_menu: QMenu):
+        """Lets the user pin Clicky's reply language instead of relying on
+        (sometimes unreliable) auto-detect from the transcript."""
+        from tutor_features.multilang import _LANG_VOICE
+
+        current = getattr(self, "_response_language", "")
+        lang_menu = parent_menu.addMenu(
+            f"Reply language: {_LANG_VOICE.get(current, ('Auto-detect',))[0] if current else 'Auto-detect'}"
+        )
+
+        auto_act = lang_menu.addAction("Auto-detect")
+        auto_act.setCheckable(True)
+        auto_act.setChecked(current == "")
+        auto_act.triggered.connect(lambda: self.on_set_response_language.emit(""))
+
+        lang_menu.addSeparator()
+        for code, (name, _voice) in _LANG_VOICE.items():
+            act = lang_menu.addAction(name)
+            act.setCheckable(True)
+            act.setChecked(current == code)
+            act.triggered.connect(lambda checked, c=code: self.on_set_response_language.emit(c))
+
+    def _build_mic_submenu(self, parent_menu: QMenu):
+        """Lists available input devices so the user can pick a mic without
+        digging through Windows sound settings."""
+        try:
+            import sounddevice as sd
+            devices = sd.query_devices()
+            default_idx = sd.default.device[0]
+        except Exception:
+            return  # sounddevice not ready yet — skip silently, not fatal
+
+        mic_menu = parent_menu.addMenu("Microphone")
+        for idx, dev in enumerate(devices):
+            if dev.get("max_input_channels", 0) <= 0:
+                continue
+            label = dev["name"]
+            if idx == default_idx:
+                label += "  (system default)"
+            act = mic_menu.addAction(label)
+            act.setCheckable(True)
+            act.setChecked(idx == getattr(self, "_active_mic_index", default_idx))
+            act.triggered.connect(lambda checked, i=idx: self.on_set_mic_device.emit(i))
 
     def _build_ollama_submenu(self, parent_menu: QMenu, providers: dict):
         """Vision/Text model pickers + 'Pull recommended' for Ollama."""

--- a/ui/tray.py
+++ b/ui/tray.py
@@ -1,4 +1,7 @@
-from PyQt6.QtWidgets import QSystemTrayIcon, QMenu
+from PyQt6.QtWidgets import (
+    QSystemTrayIcon, QMenu, QDialog, QVBoxLayout, QTextEdit,
+    QPushButton, QLabel, QHBoxLayout,
+)
 from PyQt6.QtGui import QIcon, QPixmap, QPainter, QColor, QBrush
 from PyQt6.QtCore import Qt, QSize, pyqtSignal, QObject
 
@@ -53,6 +56,7 @@ class TrayManager(QObject):
     on_diagnostics        = pyqtSignal()
     on_set_mic_device     = pyqtSignal(int)     # sounddevice input device index
     on_set_response_language = pyqtSignal(str)  # "" = auto-detect, else ISO code
+    on_set_custom_instructions = pyqtSignal(str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -73,6 +77,11 @@ class TrayManager(QObject):
         self._search_enabled = True
         self._wake_enabled = True
         self._response_language = ""
+        try:
+            from config import cfg as _cfg
+            self._custom_instructions = _cfg.custom_instructions
+        except Exception:
+            self._custom_instructions = ""
         self._slow_enabled = False
         self._quiz_enabled = False
         self._privacy_enabled = True
@@ -151,6 +160,10 @@ class TrayManager(QObject):
         self._wake_action = wake_action
 
         self._build_language_submenu(menu)
+
+        scope_label = "Instructions for Clicky…"
+        scope_action = menu.addAction(scope_label)
+        scope_action.triggered.connect(self._prompt_custom_instructions)
 
         # ── Tutor toggles ──
         menu.addSeparator()
@@ -269,6 +282,64 @@ class TrayManager(QObject):
         self._tray.setContextMenu(menu)
         # Keep refs to prevent GC
         self._menu = menu
+
+    def _prompt_custom_instructions(self):
+        dlg = QDialog(None)
+        dlg.setWindowTitle("Instructions for Clicky")
+        dlg.setMinimumSize(480, 380)
+        dlg.setStyleSheet("""
+            QDialog { background-color: #1e1e24; }
+            QLabel { color: #e8e8ec; font-size: 13px; }
+            QTextEdit {
+                background-color: #26262e; color: #f0f0f4;
+                border: 1px solid #3a3a44; border-radius: 8px;
+                padding: 10px; font-size: 13px;
+            }
+            QTextEdit:focus { border: 1px solid #7c5cff; }
+            QPushButton {
+                background-color: #3a3a44; color: #f0f0f4;
+                border: none; border-radius: 6px; padding: 8px 18px;
+                font-size: 13px;
+            }
+            QPushButton:hover { background-color: #47475400; }
+            QPushButton#primary { background-color: #7c5cff; }
+            QPushButton#primary:hover { background-color: #8f72ff; }
+        """)
+
+        layout = QVBoxLayout(dlg)
+        layout.setContentsMargins(20, 20, 20, 16)
+        layout.setSpacing(10)
+
+        title = QLabel("Instructions for Clicky")
+        title.setStyleSheet("font-size: 15px; font-weight: 600; color: #ffffff;")
+        layout.addWidget(title)
+
+        subtitle = QLabel(
+            "Replaces Clicky's core behavior (name, rules, tone).\n"
+            "{{CONTEXT}} and {{TODAY}} are placeholders — best left in."
+        )
+        subtitle.setStyleSheet("color: #9a9aa4; font-size: 12px;")
+        layout.addWidget(subtitle)
+
+        editor = QTextEdit()
+        editor.setPlainText(self._custom_instructions)
+        editor.setPlaceholderText("e.g. \"Your name is Max, a laid-back coding buddy…\"")
+        layout.addWidget(editor, stretch=1)
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(dlg.reject)
+        ok_btn = QPushButton("Save")
+        ok_btn.setObjectName("primary")
+        ok_btn.clicked.connect(dlg.accept)
+        btn_row.addWidget(cancel_btn)
+        btn_row.addWidget(ok_btn)
+        layout.addLayout(btn_row)
+
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            self._custom_instructions = editor.toPlainText().strip()
+            self.on_set_custom_instructions.emit(self._custom_instructions)
 
     def _build_language_submenu(self, parent_menu: QMenu):
         """Lets the user pin Clicky's reply language instead of relying on


### PR DESCRIPTION
Adds a "Instructions for Clicky…" tray menu item that opens a styled dialog
where users can edit Clicky's core behavior (name, rules, tone) directly —
similar to Claude's custom instructions.

- Editable text replaces the identity/rules/style section of the system
  prompt; technical drawing/pointing tag syntax stays fixed in the backend
  so pointing/drawing never breaks even if a user simplifies the prompt.
- {{CONTEXT}} / {{TODAY}} placeholders substituted at runtime.
- Persists to .env (CUSTOM_INSTRUCTIONS) so it survives restarts.
- Also fixes: reply-language setting (RESPONSE_LANGUAGE) now persists to
  .env too — previously reset on every restart.
- UI fully in English now (was mixed EN/DE from an earlier iteration).
