### PR TITLE
Performance improvements + wake-word listening fix

### DIFF
--- a/ai/lmstudio_provider.py
+++ b/ai/lmstudio_provider.py
@@ -34,6 +34,17 @@ class LMStudioProvider(BaseLLMProvider):
     def __init__(self):
         self._base = cfg.lmstudio_host.rstrip("/")
         self._model = cfg.lmstudio_model
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Reused pooled connection instead of a fresh handshake per
+        request — same latency win as the Ollama provider."""
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                timeout=120,
+                limits=httpx.Limits(max_keepalive_connections=4, max_connections=8),
+            )
+        return self._client
 
     async def stream_response(
         self,
@@ -67,53 +78,53 @@ class LMStudioProvider(BaseLLMProvider):
             "stream": True,
         }
 
-        async with httpx.AsyncClient(timeout=120) as client:
-            try:
-                async with client.stream(
-                    "POST",
-                    f"{self._base}/chat/completions",
-                    json=payload,
-                ) as response:
-                    if response.status_code == 404:
-                        raise RuntimeError(
-                            "LM Studio server not reachable at "
-                            f"{self._base}. Open LM Studio → Developer tab → "
-                            "Start Server, and make sure a model is loaded."
-                        )
-                    response.raise_for_status()
-                    async for line in response.aiter_lines():
-                        if not line.strip() or not line.startswith("data:"):
-                            continue
-                        data_str = line[len("data:"):].strip()
-                        if data_str == "[DONE]":
-                            break
-                        try:
-                            data = json.loads(data_str)
-                            delta = data["choices"][0]["delta"].get("content")
-                            if delta:
-                                yield delta
-                        except (json.JSONDecodeError, KeyError, IndexError):
-                            continue
-            except httpx.ConnectError as e:
-                raise RuntimeError(
-                    "Can't reach LM Studio. Is the local server running? "
-                    "(LM Studio → Developer tab → Start Server)"
-                ) from e
+        client = self._get_client()
+        try:
+            async with client.stream(
+                "POST",
+                f"{self._base}/chat/completions",
+                json=payload,
+            ) as response:
+                if response.status_code == 404:
+                    raise RuntimeError(
+                        "LM Studio server not reachable at "
+                        f"{self._base}. Open LM Studio → Developer tab → "
+                        "Start Server, and make sure a model is loaded."
+                    )
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.strip() or not line.startswith("data:"):
+                        continue
+                    data_str = line[len("data:"):].strip()
+                    if data_str == "[DONE]":
+                        break
+                    try:
+                        data = json.loads(data_str)
+                        delta = data["choices"][0]["delta"].get("content")
+                        if delta:
+                            yield delta
+                    except (json.JSONDecodeError, KeyError, IndexError):
+                        continue
+        except httpx.ConnectError as e:
+            raise RuntimeError(
+                "Can't reach LM Studio. Is the local server running? "
+                "(LM Studio → Developer tab → Start Server)"
+            ) from e
 
     async def health_check(self) -> bool:
         try:
-            async with httpx.AsyncClient(timeout=5) as client:
-                r = await client.get(f"{self._base}/models")
-                return r.status_code == 200
+            client = self._get_client()
+            r = await client.get(f"{self._base}/models", timeout=5)
+            return r.status_code == 200
         except Exception:
             return False
 
     async def list_models(self) -> List[str]:
         """Return model ids LM Studio currently reports via /v1/models."""
         try:
-            async with httpx.AsyncClient(timeout=5) as client:
-                r = await client.get(f"{self._base}/models")
-                data = r.json()
-                return [m["id"] for m in data.get("data", [])]
+            client = self._get_client()
+            r = await client.get(f"{self._base}/models", timeout=5)
+            data = r.json()
+            return [m["id"] for m in data.get("data", [])]
         except Exception:
             return []

--- a/ai/ollama_provider.py
+++ b/ai/ollama_provider.py
@@ -1,4 +1,5 @@
 import base64
+import os
 from typing import AsyncIterator, List
 
 import httpx
@@ -24,6 +25,18 @@ class OllamaProvider(BaseLLMProvider):
         self._base = cfg.ollama_host.rstrip("/")
         # Kept for backward compat with old code paths reading self._model
         self._model = cfg.ollama_model
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Reuses one pooled connection instead of a fresh TCP+TLS handshake
+        per request — noticeable latency win since Ollama runs on localhost
+        but every request still pays connection setup cost otherwise."""
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                timeout=120,
+                limits=httpx.Limits(max_keepalive_connections=4, max_connections=8),
+            )
+        return self._client
 
     def _pick_model(self, has_screenshots: bool) -> str:
         return cfg.get_ollama_model("vision" if has_screenshots else "text")
@@ -59,53 +72,61 @@ class OllamaProvider(BaseLLMProvider):
             "model": chosen,
             "messages": messages,
             "stream": True,
-            "options": {"num_predict": 1024},
+            # keep_alive: hold the model in VRAM/RAM between requests so the
+            # next question doesn't pay the multi-second reload cost.
+            "keep_alive": "10m",
+            "options": {
+                "num_predict": 1024,
+                "num_gpu": -1,       # offload all layers to GPU if possible
+                "num_ctx": 4096,     # enough for screenshot + short history
+                "num_thread": os.cpu_count() or 4,
+            },
         }
 
-        async with httpx.AsyncClient(timeout=120) as client:
-            async with client.stream(
-                "POST",
-                f"{self._base}/api/chat",
-                json=payload,
-            ) as response:
-                if response.status_code == 404:
-                    # Surface a useful error when the chosen model isn't
-                    # installed locally — students hit this constantly.
-                    raise RuntimeError(
-                        f"Ollama doesn't have '{chosen}' installed. "
-                        f"Run `ollama pull {chosen}` or pick another model "
-                        f"from Tray → Ollama."
-                    )
-                response.raise_for_status()
-                import json
-                async for line in response.aiter_lines():
-                    if not line.strip():
-                        continue
-                    try:
-                        data = json.loads(line)
-                        chunk = data.get("message", {}).get("content", "")
-                        if chunk:
-                            yield chunk
-                        if data.get("done"):
-                            break
-                    except json.JSONDecodeError:
-                        continue
+        client = self._get_client()
+        async with client.stream(
+            "POST",
+            f"{self._base}/api/chat",
+            json=payload,
+        ) as response:
+            if response.status_code == 404:
+                # Surface a useful error when the chosen model isn't
+                # installed locally — students hit this constantly.
+                raise RuntimeError(
+                    f"Ollama doesn't have '{chosen}' installed. "
+                    f"Run `ollama pull {chosen}` or pick another model "
+                    f"from Tray → Ollama."
+                )
+            response.raise_for_status()
+            import json
+            async for line in response.aiter_lines():
+                if not line.strip():
+                    continue
+                try:
+                    data = json.loads(line)
+                    chunk = data.get("message", {}).get("content", "")
+                    if chunk:
+                        yield chunk
+                    if data.get("done"):
+                        break
+                except json.JSONDecodeError:
+                    continue
 
     async def health_check(self) -> bool:
         try:
-            async with httpx.AsyncClient(timeout=5) as client:
-                r = await client.get(f"{self._base}/api/tags")
-                return r.status_code == 200
+            client = self._get_client()
+            r = await client.get(f"{self._base}/api/tags", timeout=5)
+            return r.status_code == 200
         except Exception:
             return False
 
     async def list_models(self) -> List[str]:
         """Return all installed model names (flat list)."""
         try:
-            async with httpx.AsyncClient(timeout=5) as client:
-                r = await client.get(f"{self._base}/api/tags")
-                data = r.json()
-                return [m["name"] for m in data.get("models", [])]
+            client = self._get_client()
+            r = await client.get(f"{self._base}/api/tags", timeout=5)
+            data = r.json()
+            return [m["name"] for m in data.get("models", [])]
         except Exception:
             return []
 

--- a/audio/ambient_listener.py
+++ b/audio/ambient_listener.py
@@ -33,6 +33,9 @@ SILENCE_BLOCKS_END = 20              # ~600ms of silence ends a segment
 MAX_SEGMENT_BLOCKS = 120             # ~3.6s max wake-word segment
 PRE_ROLL_BLOCKS    = 18              # ~540ms of pre-roll for the wake word
 
+REC_MIN_SPEECH_BLOCKS  = 3    # ~90ms of speech before we start tracking end-silence
+REC_SILENCE_BLOCKS_END = 22   # ~660ms of silence after speech ends the recording
+
 # Wake phrases — whisper tiny often mis-transcribes "clicky" so we cover variants
 WAKE_WORDS = (
     "clicky", "click e", "click he", "click me", "clickie", "clicki",
@@ -75,6 +78,9 @@ class AmbientListener:
 
         # Recording buffer (hotkey push-to-talk OR post-wake capture)
         self._rec_buffer: list[bytes] = []
+        self._rec_speech_blocks = 0
+        self._rec_started_speech = False
+        self._rec_silence_blocks = 0
 
         # Lazy tiny whisper for wake word
         self._wake_model = None
@@ -129,7 +135,16 @@ class AmbientListener:
     def start_recording(self) -> None:
         """Switch to RECORDING mode; all audio buffered for STT."""
         self._rec_buffer = []
+        self._rec_speech_blocks = 0
+        self._rec_started_speech = False
+        self._rec_silence_blocks = 0
         self._mode = Mode.RECORDING
+
+    def recording_should_stop(self) -> bool:
+        """True once the user has spoken and then paused long enough that
+        they're clearly done — lets the caller end the recording as soon as
+        they finish talking instead of waiting out a fixed timeout."""
+        return self._rec_started_speech and self._rec_silence_blocks >= REC_SILENCE_BLOCKS_END
 
     def stop_recording(self) -> bytes:
         """Return buffered PCM16 bytes and resume standby."""
@@ -164,6 +179,14 @@ class AmbientListener:
 
         if self._mode == Mode.RECORDING:
             self._rec_buffer.append(pcm_int16.tobytes())
+            is_speech = rms > ENERGY_THRESHOLD
+            if is_speech:
+                self._rec_speech_blocks += 1
+                self._rec_silence_blocks = 0
+                if self._rec_speech_blocks >= REC_MIN_SPEECH_BLOCKS:
+                    self._rec_started_speech = True
+            elif self._rec_started_speech:
+                self._rec_silence_blocks += 1
             return
 
         # Standby: VAD-based segment capture for wake-word

--- a/audio/tts/base_tts.py
+++ b/audio/tts/base_tts.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 
 class BaseTTS(ABC):
@@ -7,3 +8,11 @@ class BaseTTS(ABC):
     async def speak(self, text: str) -> None:
         """Synthesize and play audio for the given text."""
         ...
+
+    async def synthesize(self, text: str) -> Optional[bytes]:
+        """Optional: synthesize audio WITHOUT playing it, so the next
+        sentence's audio can be generated while the current one still
+        plays (removes the network round-trip from perceived latency).
+        Providers that don't implement this return None — speak() still
+        works, just without the prefetch win."""
+        return None

--- a/audio/tts/edge_tts_provider.py
+++ b/audio/tts/edge_tts_provider.py
@@ -26,14 +26,19 @@ class EdgeTTSProvider(BaseTTS):
     async def speak(self, text: str) -> None:
         if not text.strip():
             return
+        data = await self.synthesize(text)
+        if data:
+            await play_mp3_async(data)
 
+    async def synthesize(self, text: str):
+        if not text.strip():
+            return None
         communicate = edge_tts.Communicate(text, self._voice)
         buf = io.BytesIO()
         async for chunk in communicate.stream():
             if chunk["type"] == "audio":
                 buf.write(chunk["data"])
-
-        await play_mp3_async(buf.getvalue())
+        return buf.getvalue()
 
     @staticmethod
     def list_voices_sync() -> list:

--- a/companion_manager.py
+++ b/companion_manager.py
@@ -534,12 +534,16 @@ class CompanionManager(QObject):
         self._emit_state(AppState.LISTENING)
 
     async def _auto_stop_after_pause(self):
-        """When triggered by wake word, wait for user to finish speaking."""
+        """When triggered by wake word, wait for the user to finish
+        speaking — ends as soon as silence is detected after they've
+        talked, instead of always waiting out the full timeout."""
         import time
         max_total_s = 10.0
         start_t = time.monotonic()
         while self._state == AppState.LISTENING:
-            await asyncio.sleep(0.15)
+            await asyncio.sleep(0.1)
+            if self._listener.recording_should_stop():
+                break
             if time.monotonic() - start_t > max_total_s:
                 break
         await self._end_capture_and_process()
@@ -852,7 +856,7 @@ class CompanionManager(QObject):
             # 6. Update per-app history
             history.append(Message(role="user", content=transcript))
             history.append(Message(role="assistant", content=full_response))
-            self._app_memory[ak] = history[-20:]
+            self._app_memory[ak] = history[-10:]
 
             # Multistep: parse numbered steps for later "next" invocations
             if multistep and not self._lesson_steps:
@@ -1210,7 +1214,9 @@ class CompanionManager(QObject):
             _shape_length = None
 
         draw_end = time.monotonic()
-        for text, shapes in segments:
+        tts = self._get_tts()
+        prefetch_task = None
+        for idx, (text, shapes) in enumerate(segments):
             if self._cancel_flag:
                 break
             draw_end = max(draw_end, time.monotonic())
@@ -1224,7 +1230,22 @@ class CompanionManager(QObject):
                     draw_end += 1.0
             if text:
                 try:
-                    await self._get_tts().speak(_speakable(text))
+                    # Use audio already being generated during the previous
+                    # segment's playback if we have it; otherwise synthesize
+                    # now (first segment, or a provider without prefetch).
+                    audio = await prefetch_task if prefetch_task else await tts.synthesize(_speakable(text))
+                    prefetch_task = None
+                    # Start the NEXT segment's TTS generation now, in
+                    # parallel with playing this one — removes the network
+                    # round-trip from between-sentence latency.
+                    next_text = segments[idx + 1][0] if idx + 1 < len(segments) else None
+                    if next_text:
+                        prefetch_task = asyncio.ensure_future(tts.synthesize(_speakable(next_text)))
+                    if audio:
+                        from audio.playback import play_mp3_async
+                        await play_mp3_async(audio)
+                    else:
+                        await tts.speak(_speakable(text))
                 except asyncio.CancelledError:
                     raise
                 except Exception:

--- a/config.py
+++ b/config.py
@@ -32,9 +32,12 @@ HARD RULES (never break):
      Point at it and explain in ONE sentence. If it's not visible, say so
      plainly instead of guessing.
 
-  2. MULTI-STEP TASKS (export, install, configure, setup, etc.):
-     Describe ONLY the next single step, then end with "Say 'next' when
-     ready." Never dump a numbered list of 5 steps in one response.
+  2. MULTI-STEP TASKS (export, install, configure, setup — things with
+     several genuinely separate physical steps): describe ONLY the next
+     single step, then end with "Say 'next' when ready." Do NOT use this
+     pattern for simple questions, one-step answers, explanations, or
+     anything that isn't a multi-step procedure — most responses do NOT
+     end with "say next," only ones where more steps are still coming.
 
   3. VISION: describe only what is ACTUALLY in the screenshot. Trust your
      eyes over the user's words.

--- a/screen/capture.py
+++ b/screen/capture.py
@@ -65,7 +65,7 @@ def _query_dpi_scale() -> float:
         return 1.0
 
 
-def capture_all_screens(max_width: int = 1280) -> List[ScreenShot]:
+def capture_all_screens(max_width: int = 1024) -> List[ScreenShot]:
     """Capture all monitors. Each ScreenShot carries everything needed
     to convert detection coords back into logical screen space."""
     dpi = _query_dpi_scale()


### PR DESCRIPTION
Performance:
- Smaller screenshot (1280→1024px) — less upload/tokens
- Shorter per-app history (20→10 messages)
- Ollama: keep_alive + full GPU offload + thread count
- Pooled httpx connections for Ollama/LM Studio (no per-request handshake)
- TTS prefetch — next sentence synthesizes while current one plays

Fixes:
- Wake-word capture now ends as soon as the user stops talking, instead of always waiting out a fixed 10s timeout
- Softened the "MULTI-STEP TASKS" prompt rule — smaller local models were over-applying "Say 'next' when ready" to every response

Tested locally with LM Studio (qwen2.5-vl-7b) + whisper.cpp medium.