### PR TITLE
Modernize deprecated asyncio.get_event_loop() calls

### DIFF
--- a/audio/playback.py
+++ b/audio/playback.py
@@ -102,7 +102,7 @@ async def play_mp3_async(mp3_bytes: bytes) -> None:
 
     _arm_audio()
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     pcm, sr = await loop.run_in_executor(None, decode_mp3_to_pcm, mp3_bytes)
     if pcm.size == 0:
         return

--- a/audio/stt/faster_whisper_stt.py
+++ b/audio/stt/faster_whisper_stt.py
@@ -28,7 +28,7 @@ class FasterWhisperSTT(BaseSTT):
     async def transcribe(self, pcm_bytes: bytes, sample_rate: int = 16000) -> str:
         pcm_bytes = trim_silence(pcm_bytes)
         wav_bytes = pcm16_to_wav(pcm_bytes, sample_rate)
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._run, wav_bytes)
 
     def _run(self, wav_bytes: bytes) -> str:

--- a/audio/stt/whisper_cpp_stt.py
+++ b/audio/stt/whisper_cpp_stt.py
@@ -73,7 +73,7 @@ class WhisperCppSTT(BaseSTT):
             return ""
         pcm_bytes = trim_silence(pcm_bytes)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._sync_transcribe, pcm_bytes)
 
     def _sync_transcribe(self, pcm_bytes: bytes) -> str:


### PR DESCRIPTION
Replaces asyncio.get_event_loop() with get_running_loop() in 3 files
(audio/stt/whisper_cpp_stt.py, audio/stt/faster_whisper_stt.py,
audio/playback.py). Functionally identical here since these are always
called from within a running coroutine, but get_event_loop() is
deprecated for this use case and Python is moving toward removing its
implicit loop-creation behavior — future-proofing before it breaks.

No behavior change, low-risk.