### PR TITLE
feat: add Greek language support

### DIFF
--- a/tutor_features/multilang.py
+++ b/tutor_features/multilang.py
@@ -34,6 +34,7 @@ _LANG_VOICE = {
     "te": ("Telugu",    "te-IN-ShrutiNeural"),
     "bn": ("Bengali",   "bn-IN-TanishaaNeural"),
     "ur": ("Urdu",      "ur-PK-UzmaNeural"),
+    "el": ("Greek",     "el-GR-AthinaNeural"),
 }
 
 
@@ -47,6 +48,7 @@ def _script_heuristic(text: str) -> str:
     if re.search(r"[一-鿿]", text):    return "zh"   # Han
     if re.search(r"[぀-ヿ]", text):    return "ja"   # Hiragana/Katakana
     if re.search(r"[가-힯]", text):    return "ko"   # Hangul
+    if re.search("[Ͱ-Ͽἀ-῿]", text): return "el"   # Greek
     if re.search(r"[Ѐ-ӿ]", text):    return "ru"   # Cyrillic
     return "en"
 


### PR DESCRIPTION
## Problem

Greek (el) was missing from the language map despite the app shipping with 16 other languages.

## Fix

- Added `"el": ("Greek", "el-GR-AthinaNeural")` to `_LANG_VOICE`
- Added a Greek script check (Ͱ-Ͽ, ἀ-῿) before the Cyrillic one so Greek text routes correctly

## Verification

- Greek, Russian, Hindi, Chinese, and English all route correctly in unit tests
- Both `el-GR` Edge voices probed as live

## Test plan

- [ ] Ask Clicky a question in Greek and confirm it answers in Greek with the Athina voice
- [ ] Verify Russian and other Cyrillic text still routes to Russian

🤖 Generated with [Claude Code](https://claude.ai/code)
